### PR TITLE
Fix ffmpeg extension entrypoint

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -11,13 +11,6 @@
             "version": "21.08",
             "add-ld-path": ".",
             "no-autodownload": false
-        },
-        "org.freedesktop.Platform.VAAPI.Intel": {
-            "directory": "lib",
-            "version": "21.08",
-            "add-ld-path": ".",
-            "download-if": "have-intel-gpu",
-            "no-autodownload": false
         }
     },
     "command": "yuzu",

--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -213,6 +213,7 @@
                 "/share/pixmaps"
             ],
             "post-install": [
+                "mkdir -p /app/lib/ffmpeg",
                 "install -Dm644 ../org.yuzu_emu.yuzu.metainfo.xml /app/share/appdata/org.yuzu_emu.yuzu.metainfo.xml",
                 "desktop-file-install --dir=/app/share/applications ../dist/yuzu.desktop",
                 "desktop-file-edit --set-key StartupWMClass --set-value yuzu /app/share/applications/yuzu.desktop",


### PR DESCRIPTION
Fix
```
> flatpak run org.yuzu_emu.yuzu
bwrap: Can't mkdir /app/lib/ffmpeg: Read-only file system
error: ldconfig failed, exit status 256
```