### PR TITLE
Drag&Drop Fix

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -13,7 +13,8 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--share=network",
-        "--share=ipc"
+        "--share=ipc",
+        "--filesystem=xdg-run/app/com.discordapp.Discord:create"
     ],
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"

--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -14,7 +14,9 @@
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",
-        "--filesystem=xdg-run/app/com.discordapp.Discord:create"
+        "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+        "--filesystem=home:ro",
+        "--filesystem=/run/media:ro"
     ],
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"

--- a/yuzu-launcher.sh
+++ b/yuzu-launcher.sh
@@ -13,6 +13,12 @@ EOF
     zenity --warning --no-wrap --title "That's awkward ..." --text "$MESSAGE"
 }
 
+# Discord RPC
+for i in {0..9}; do
+    test -S $XDG_RUNTIME_DIR/discord-ipc-$i || ln -sf {app/com.discordapp.Discord,$XDG_RUNTIME_DIR}/discord-ipc-$i;
+done
+
+
 if ! prlimit --nofile=8192 yuzu "$@"; then
     report_error
 fi


### PR DESCRIPTION
Allowing this access by default will prevent the issue as noted in #260 .

This will also prevent the application from crashing when you open one ROM File with Yuzu from the system file explorer.