### PR TITLE
Move compatibility list before build

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -265,7 +265,8 @@
                 },
                 {
                     "type": "file",
-                    "path": "compatibility_list.json"
+                    "path": "compatibility_list.json",
+                    "dest": "dist/compatibility_list"
                 }
             ]
         }


### PR DESCRIPTION
CMake will now use an existing compatiblity list in `dist/compatiblity_list` in the build directory if it exists (yuzu-emu/yuzu#8485 and yuzu-emu/yuzu-mainline@2e3204ad04e6ce13de83c06a6b67f4ba0a12cbce). Fixes one of the issues in #6.