### PR TITLE
Read-only access to Discord IPC socket directory

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -12,7 +12,7 @@
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",
-        "--filesystem=xdg-run/app/com.discordapp.Discord:create",
+        "--filesystem=xdg-run/app/com.discordapp.Discord:ro",
         "--filesystem=home:ro",
         "--filesystem=/run/media:ro",
         "--talk-name=org.freedesktop.login1.Manager"


### PR DESCRIPTION
Write access is not required to connect to the socket. It's only required to create it, which is done by Discord.