### PR TITLE
Fix Git URL for nv-codec-headers

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -193,7 +193,7 @@
             "sources": [
                 {
                     "type": "git",
-                    "url": "https://git.videolan.org/git/ffmpeg/nv-codec-headers.git",
+                    "url": "https://github.com/ffmpeg/nv-codec-headers.git",
                     "tag": "n12.0.16.0",
                     "commit": "c5e4af74850a616c42d39ed45b9b8568b71bf8bf",
                     "x-checker-data": {


### PR DESCRIPTION
This change uses the GitHub mirror for `ffmpeg/nv-codec-headers` instead of the `git.videolan.org` URL.

The current Git URL for the `ffmpeg/nv-codec-headers` causes @flathubbot to fail repeatedly with each new yuzu mainline. This is due to the VideoLAN Git subdomain having an invalid/expired SSL certificate.