### PR TITLE
added Wayland support

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -6,7 +6,8 @@
     "command": "yuzu-launcher",
     "finish-args": [
         "--device=all",
-        "--socket=fallback-x11",
+        "--socket=x11",
+        "--socket=wayland",
         "--socket=pulseaudio",
         "--share=network",
         "--share=ipc",

--- a/yuzu-launcher.sh
+++ b/yuzu-launcher.sh
@@ -13,7 +13,6 @@ EOF
     zenity --warning --no-wrap --title "That's awkward ..." --text "$MESSAGE"
 }
 
-export QT_QPA_PLATFORM=xcb
 # Discord RPC
 for i in {0..9}; do
     test -S "$XDG_RUNTIME_DIR"/"discord-ipc-$i" || ln -sf {app/com.discordapp.Discord,"$XDG_RUNTIME_DIR"}/"discord-ipc-$i";


### PR DESCRIPTION
fixed #1113 

Updated the manifest to support Wayland and disabled the forced xcb backend.

Tested on KDE Plasma Wayland 5.27.5 and gamescope 