### PR TITLE
manifest: update fmt to 10.1.1

### DIFF
--- a/org.yuzu_emu.yuzu.json
+++ b/org.yuzu_emu.yuzu.json
@@ -84,13 +84,13 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/fmtlib/fmt/releases/download/9.1.0/fmt-9.1.0.zip",
-                    "sha256": "cceb4cb9366e18a5742128cb3524ce5f50e88b476f1e54737a47ffdf4df4c996",
+                    "url": "https://github.com/fmtlib/fmt/releases/download/10.1.1/fmt-10.1.1.zip",
+                    "sha256": "b84e58a310c9b50196cda48d5678d5fa0849bca19e5fdba6b684f0ee93ed9d1b",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 11526,
                         "versions": {
-                            "<": "10.0.0"
+                            "<": "11.0.0"
                         },
                         "url-template": "https://github.com/fmtlib/fmt/releases/download/$version/fmt-$version.zip"
                     }


### PR DESCRIPTION
This pull request updates `fmt` to 10.1.1.